### PR TITLE
Updated ghost element hover and selected colours

### DIFF
--- a/themes/axolosin.json
+++ b/themes/axolosin.json
@@ -40,9 +40,9 @@
         "element.disabled":                               "#626262FF",
 
         "ghost_element.background":                       "#00000000",
-        "ghost_element.hover":                            "#20202077",
+        "ghost_element.hover":                            "#61104860",
         "ghost_element.active":                           "#393939D0",
-        "ghost_element.selected":                         "#111111FF",
+        "ghost_element.selected":                         "#310838AA",
         "ghost_element.disabled":                         "#515151FF",
 
         "text":                                           "#D7D7D7FF",


### PR DESCRIPTION
Ghost element hover and selection colours are currently almost transparent or simple (gray). This makes it very difficult for users to know which element is currently selected within a popup (code completions, action menu, etc.) - the selection colour highlights the entry that is currently chosen via the keyboard, while the hover colour highlights the entry that is pointed to by the mouse.

Changing these colours to be more vibrant and noticeable.