### PR TITLE
Added themed colouring for text cursor and text selection

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "axolosin"
 name = "Axolosin Theme"
 description = "An Axolotl-inspired theme for Zed"
-version = "1.0.0"
+version = "1.1.0"
 schema_version = 1
 authors = ["Alok Meshram <meshram.alok@gmail.com>"]
 repository = "https://github.com/LightTreasure/zed-axolosin-theme"

--- a/themes/axolosin.json
+++ b/themes/axolosin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
   "name": "Axolosin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Alok Meshram <meshram.alok@gmail.com>",
   "themes": [
     {
@@ -148,7 +148,12 @@
         "terminal.ansi.bright_white":                     "#F8F8F2",
         "terminal.ansi.dim_white":                        null,
 
-        "players": [],
+        "players": [
+          {
+            "cursor":             "#77FF00FF",
+            "selection":          "#110838A0"
+          }
+        ],
 
         "editor.document_highlight.read_background":      "#302d4d",
         "editor.document_highlight.write_background":     "#2f3e5e",


### PR DESCRIPTION
Zed's default text cursor colour and text selection colour doesn't really get with this theme. 
- Added colours that work better with the rest of the theme. 
- Updated version to 1.1.0