### PR TITLE
Change the scrollbar_thumb.background style property to scrollbar.thumb.background

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "axolosin"
 name = "Axolosin Theme"
 description = "An Axolotl-inspired theme for Zed"
-version = "1.1.0"
+version = "1.1.1"
 schema_version = 1
 authors = ["Alok Meshram <meshram.alok@gmail.com>"]
 repository = "https://github.com/LightTreasure/zed-axolosin-theme"

--- a/themes/axolosin.json
+++ b/themes/axolosin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
   "name": "Axolosin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Alok Meshram <meshram.alok@gmail.com>",
   "themes": [
     {
@@ -68,7 +68,7 @@
         "icon.placeholder":                               null,
         "icon.accent":                                    null,
 
-        "scrollbar_thumb.background":                     "#88888811",
+        "scrollbar.thumb.background":                     "#88888811",
         "scrollbar.thumb.hover_background":               "#88888811",
         "scrollbar.thumb.border":                         "#00000011",
         "scrollbar.track.background":                     "#000000CC",


### PR DESCRIPTION
Zed has deprecated `scrollbar_thumb.background` in favor of `scrollbar.thumb.background`: https://github.com/zed-industries/zed/pull/8004 

Closes #5 .